### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,7 @@ language: cpp
 matrix:
   include:
     - compiler: gcc
-      env:
-        - COMPILER=gcc-4.8
-        - CXX=g++-4.8
-        - CC=gcc-4.8
+      env: COMPILER=gcc-4.8
     - compiler: gcc
       addons:
         apt:
@@ -16,10 +13,7 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
-      env:
-        - COMPILER=g++-4.9
-        - CXX=g++-4.9
-        - CC=gcc-4.9
+      env: COMPILER=g++-4.9
     - compiler: gcc
       addons:
         apt:
@@ -27,15 +21,9 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
-      env:
-        - COMPILER=g++-5
-        - CXX=g++-5.0
-        - CC=gcc-5.0
+      env: COMPILER=g++-5
     - compiler: clang
-      env:
-        - COMPILER=clang++-3.5
-        - CXX=clang++-3.5
-        - CC=clang-3.5
+      env: COMPILER=clang++-3.5
     - compiler: clang
       addons:
         apt:
@@ -44,10 +32,7 @@ matrix:
             - llvm-toolchain-precise-3.6
           packages:
             - clang-3.6
-      env:
-        - COMPILER=clang++-3.6
-        - CXX=clang++-3.6
-        - CC=clang-3.6
+      env: COMPILER=clang++-3.6
     - compiler: clang
       addons:
         apt:
@@ -56,13 +41,12 @@ matrix:
             - llvm-toolchain-precise-3.7
           packages:
             - clang-3.7
-      env:
-        - COMPILER=clang++-3.7
-        - CXX=clang++-3.7
-        - CC?clang-3.7
+      env: COMPILER=clang++-3.7
 
 
 before_script:
+ - export CXX=$COMPILER
+ - export CC=$COMPILER
  - $CXX --version
  - $CC --version
  - tools/linux_x64/premake5 --file=tests/premake5.lua gmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,13 @@
+sudo: required
+dist: trusty
 language: cpp
 
 compiler:
  - gcc
  - clang
 
-before_install:
- - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
- - sudo apt-get update -qq
- - sudo apt-get install -qq libyajl-dev libxml2-dev libxqilla-dev
-
 install:
- - if [ "$CXX" = "clang++" ]; then sudo apt-get install -qq libstdc++-4.8-dev; fi
- - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
- - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+ - $CXX --version
 
 before_script:
  - tools/linux_x64/premake5 --file=tests/premake5.lua gmake

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,42 @@ sudo: required
 dist: trusty
 language: cpp
 
-compiler:
- - gcc
- - clang
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env: COMPILER=g++-4.9
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env: COMPILER=g++-5
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+      env: COMPILER=clang++-3.6
+    - compiler: clang
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.7
+          packages:
+            - clang-3.7
+      env: COMPILER=clang++-3.7
 
 install:
  - $CXX --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: cpp
 matrix:
   include:
     - compiler: gcc
-      env: COMPILER=gcc-4.8
+      env: COMPILER=gcc
     - compiler: gcc
       addons:
         apt:
@@ -23,7 +23,7 @@ matrix:
             - g++-5
       env: COMPILER=g++-5
     - compiler: clang
-      env: COMPILER=clang++-3.5
+      env: COMPILER=clang++
     - compiler: clang
       addons:
         apt:
@@ -46,9 +46,7 @@ matrix:
 
 before_script:
  - export CXX=$COMPILER
- - export CC=$COMPILER
  - $CXX --version
- - $CC --version
  - tools/linux_x64/premake5 --file=tests/premake5.lua gmake
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: cpp
 matrix:
   include:
     - compiler: gcc
-      env: COMPILER=gcc
+      env: COMPILER=g++
     - compiler: gcc
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,10 @@ language: cpp
 matrix:
   include:
     - compiler: gcc
-      env: COMPILER=gcc-4.8
+      env:
+        - COMPILER=gcc-4.8
+        - CXX=g++-4.8
+        - CC=gcc-4.8
     - compiler: gcc
       addons:
         apt:
@@ -13,7 +16,10 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-4.9
-      env: COMPILER=g++-4.9
+      env:
+        - COMPILER=g++-4.9
+        - CXX=g++-4.9
+        - CC=gcc-4.9
     - compiler: gcc
       addons:
         apt:
@@ -21,9 +27,15 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - g++-5
-      env: COMPILER=g++-5
+      env:
+        - COMPILER=g++-5
+        - CXX=g++-5.0
+        - CC=gcc-5.0
     - compiler: clang
-      env: COMPILER=clang++-3.5
+      env:
+        - COMPILER=clang++-3.5
+        - CXX=clang++-3.5
+        - CC=clang-3.5
     - compiler: clang
       addons:
         apt:
@@ -32,7 +44,10 @@ matrix:
             - llvm-toolchain-precise-3.6
           packages:
             - clang-3.6
-      env: COMPILER=clang++-3.6
+      env:
+        - COMPILER=clang++-3.6
+        - CXX=clang++-3.6
+        - CC=clang-3.6
     - compiler: clang
       addons:
         apt:
@@ -41,11 +56,15 @@ matrix:
             - llvm-toolchain-precise-3.7
           packages:
             - clang-3.7
-      env: COMPILER=clang++-3.7
+      env:
+        - COMPILER=clang++-3.7
+        - CXX=clang++-3.7
+        - CC?clang-3.7
 
 
 before_script:
  - $CXX --version
+ - $CC --version
  - tools/linux_x64/premake5 --file=tests/premake5.lua gmake
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: cpp
 matrix:
   include:
     - compiler: gcc
+      env: COMPILER=gcc-4.8
+    - compiler: gcc
       addons:
         apt:
           sources:
@@ -20,6 +22,8 @@ matrix:
           packages:
             - g++-5
       env: COMPILER=g++-5
+    - compiler: clang
+      env: COMPILER=clang++-3.5
     - compiler: clang
       addons:
         apt:
@@ -39,10 +43,9 @@ matrix:
             - clang-3.7
       env: COMPILER=clang++-3.7
 
-install:
- - $CXX --version
 
 before_script:
+ - $CXX --version
  - tools/linux_x64/premake5 --file=tests/premake5.lua gmake
 
 script:


### PR DESCRIPTION
Updated the travis-ci configuration to use the trusty image, and there are now jobs for building with:
 - gcc 4.8
 - gcc 4.9
 - gcc 5.0
 - clang 3.5
 - clang 3.6
 - clang 3.7