### PR TITLE
Disconnect all slots tests

### DIFF
--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -336,23 +336,7 @@ namespace nod {
 
 			// Destruct the signal object.
 			~signal_type() {
-				// If we are unlucky, some of the connected slots
-				// might be in the process of disconnecting from other threads.
-				// If this happens, we are risking to destruct the disconnector
-				// object managed by our shared pointer before they are done
-				// disconnecting. This would be bad. To solve this problem, we
-				// discard the shared pointer (that is pointing to the disconnector
-				// object within our own instance), but keep a weak pointer to that
-				// instance. We then stall the destruction until all other weak
-				// pointers have released their "lock" (indicated by the fact that
-				// we will get a nullptr when locking our weak pointer).
-				std::weak_ptr<detail::disconnector> weak{_shared_disconnector};
-				_shared_disconnector.reset();
-				while( weak.lock() != nullptr )	{
-					// we just yield here, allowing the OS to reschedule. We do
-					// this until all threads has released the disconnector object.
-					thread_policy::yield_thread();
-				}
+				invalidate_disconnector();
 			}
 
 			/// Type that will be used to store the slots for this signal type.
@@ -491,6 +475,32 @@ namespace nod {
 			using mutex_type = typename thread_policy::mutex_type;
 			/// Type of mutex lock, provided by threading policy
 			using mutex_lock_type = typename thread_policy::mutex_lock_type;
+
+			/// Invalidate the internal disconnector object in a way
+			/// that is safe according to the current thread policy.
+			///
+			/// This will effectively make all current connection objects to
+			/// to this signal incapable of disconnecting, since they keep a
+			/// weak pointer to the shared disconnector object.
+			void invalidate_disconnector() {
+				// If we are unlucky, some of the connected slots
+				// might be in the process of disconnecting from other threads.
+				// If this happens, we are risking to destruct the disconnector
+				// object managed by our shared pointer before they are done
+				// disconnecting. This would be bad. To solve this problem, we
+				// discard the shared pointer (that is pointing to the disconnector
+				// object within our own instance), but keep a weak pointer to that
+				// instance. We then stall the destruction until all other weak
+				// pointers have released their "lock" (indicated by the fact that
+				// we will get a nullptr when locking our weak pointer).
+				std::weak_ptr<detail::disconnector> weak{_shared_disconnector};
+				_shared_disconnector.reset();
+				while( weak.lock() != nullptr )	{
+					// we just yield here, allowing the OS to reschedule. We do
+					// this until all threads has released the disconnector object.
+					thread_policy::yield_thread();
+				}
+			}
 
 			/// Retrieve a copy of the current slots
 			///

--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -465,6 +465,7 @@ namespace nod {
 				mutex_lock_type lock{ _mutex };
 				_slots.clear();
 				_slot_count = 0;
+				invalidate_disconnector();
 			}
 
 		private:

--- a/tests/tests/disconnect_all_slots_tests.cpp
+++ b/tests/tests/disconnect_all_slots_tests.cpp
@@ -1,0 +1,66 @@
+#include <catch.hpp>
+
+#include <nod/nod.hpp>
+
+#include <iostream>
+#include <strstream>
+
+SCENARIO( "Connection objects are forced disconnected when disconnecting all slots from a signal" ) {
+	GIVEN("A signal") {
+		std::ostringstream ss;
+		nod::signal<void(std::string const&)> signal;
+		WHEN("Two slots gets connected") {
+			auto connection1 = signal.connect([&ss](std::string const& str){
+				ss << "1: " << str << "\n";
+			});
+			auto connection2 = signal.connect([&ss](std::string const& str){
+				ss << "2: " << str << "\n";
+			});
+			THEN("both connections are considered connected") {
+				REQUIRE( connection1.connected() == true );
+				REQUIRE( connection2.connected() == true );
+			}
+			AND_WHEN("the signal is triggered") {
+				signal("testing");
+				THEN("both slots get called in connection order") {
+					REQUIRE( ss.str() == "1: testing\n2: testing\n" );
+				}
+			}
+			AND_WHEN("we force disconnect all slots from the signal") {
+				signal.disconnect_all_slots();
+				THEN("both connections are considered disconnected") {
+					REQUIRE( connection1.connected() == false );
+					REQUIRE( connection2.connected() == false );
+					AND_WHEN("we try to disconnect the slots") {
+						connection1.disconnect();
+						connection2.disconnect();
+						THEN("nothing changes") {
+							REQUIRE( connection1.connected() == false );
+							REQUIRE( connection2.connected() == false );
+						}
+					}
+				}
+				AND_WHEN("the signal is triggered") {
+					signal("again");
+					THEN("no slots are called") {
+						REQUIRE( ss.str() == "" );
+					}
+				}
+				AND_WHEN("we connect a new slot to the signal") {
+					auto connection3 = signal.connect([&ss](std::string const& str){
+						ss << "3: " << str << "\n";
+					});
+					THEN("the connection is considered connected") {
+						REQUIRE( connection3.connected() == true );
+					}
+					AND_WHEN("we trigger the signal") {
+						signal("third time");
+						THEN("only the new slot is called") {
+							REQUIRE( ss.str() == "3: third time\n" );
+						}
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Added test case for `signal.disconnect_all_slots()` and fixed the implementation so that the test case don't fail.