### PR TITLE
Added move assignment operator for scoped connection

### DIFF
--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -118,6 +118,13 @@ namespace nod {
 				_connection( std::move(other._connection) )
 			{}
 
+			/// Move assign operator.
+			/// @param other   The instance to move from.
+			scoped_connection& operator=( scoped_connection&& other ) {
+				_connection = std::move( other._connection );
+				return *this;
+			}
+
 			/// Construct a scoped connection from a connection object
 			/// @param connection   The connection object to manage
 			scoped_connection( connection&& c ) :

--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -121,7 +121,7 @@ namespace nod {
 			/// Move assign operator.
 			/// @param other   The instance to move from.
 			scoped_connection& operator=( scoped_connection&& other ) {
-				_connection = std::move( other._connection );
+				reset( std::forward<connection>( other._connection ) );
 				return *this;
 			}
 


### PR DESCRIPTION
Added move assignment operator for scoped connection.

@fr00b0: We are using nod in our software project and wanna enforce the usage of scoped_connections by just returning scoped_connections instead of connections by our internal classes. To be able to do this we need the scoped_connection to be move assignable so thats why I have started this pull request.

If it doesn't comply with your design then let me know. Thanks in advance for looking into this.