### PR TITLE
Scoped connection tests

### DIFF
--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -121,7 +121,7 @@ namespace nod {
 			/// Move assign operator.
 			/// @param other   The instance to move from.
 			scoped_connection& operator=( scoped_connection&& other ) {
-				reset( std::forward<connection>( other._connection ) );
+				reset( std::move( other._connection ) );
 				return *this;
 			}
 

--- a/tests/tests/connection_tests.cpp
+++ b/tests/tests/connection_tests.cpp
@@ -125,8 +125,8 @@ SCENARIO( "Scoped connection will disconnect when destroyed" ) {
 	GIVEN( "A signal" ) {
 		std::ostringstream ss;
 		nod::signal<void()> signal;
-		WHEN( "A slot get's connected and managed by a scoped connection" ) {
-			auto connection = test::make_unique<nod::scoped_connection>( signal.connect([&](){ ss << "singaled!"; }) );
+		WHEN( "A slot gets connected and managed by a scoped connection" ) {
+			auto connection = test::make_unique<nod::scoped_connection>( signal.connect([&](){ ss << "signaled!"; }) );
 			THEN( "the connection is considered connected" ) {
 				REQUIRE( connection->connected() == true );
 			}

--- a/tests/tests/connection_tests.cpp
+++ b/tests/tests/connection_tests.cpp
@@ -121,6 +121,43 @@ SCENARIO( "Scoped connection objects are default constructible" ) {
 	}
 }
 
+SCENARIO( "Scoped connection objects are move constructible" ) {
+	GIVEN( "a signal with a connected slot, managed by a scoped connection" ) {
+		nod::signal<void()> signal;
+		std::ostringstream ss;
+		nod::scoped_connection scoped1 = signal.connect([&](){ ss << "signaled!"; });
+		WHEN( "a new scoped connection can be move assigned from the original scoped connection" ) {
+			nod::scoped_connection scoped2 = std::move(scoped1);
+			THEN( "the new connection is connected" ) {
+				REQUIRE( scoped2.connected() == true );
+			}
+			AND_WHEN( "firing the signal triggers the slot only once" ) {
+				signal();
+				REQUIRE( ss.str() == "signaled!" );
+			}
+		}
+	}
+	GIVEN( "two signals connected to a slot, managed by two scoped connections" ) {
+		nod::signal<void()> signal;
+		std::ostringstream ss;
+		nod::scoped_connection connection1 = signal.connect([&](){ ss << "1"; });
+		nod::scoped_connection connection2 = signal.connect([&](){ ss << "2"; });
+		REQUIRE( signal.slot_count() == 2 );
+		WHEN( "we move assign the first of the connections with the second one" ) {
+			connection1 = std::move(connection2);
+			THEN( "the signal only has one connected slot") {
+				REQUIRE( signal.slot_count() == 1 );
+			}
+			AND_WHEN( "we trigger the signal" ) {
+				signal();
+				THEN( "only the second slot is executed" ) {
+					REQUIRE( ss.str() == "2" );
+				}
+			}
+		}
+	}
+}
+
 SCENARIO( "Scoped connection will disconnect when destroyed" ) {
 	GIVEN( "A signal" ) {
 		std::ostringstream ss;

--- a/tests/tests/connection_tests.cpp
+++ b/tests/tests/connection_tests.cpp
@@ -113,6 +113,7 @@ SCENARIO( "Signals will disconnect all slots when destroyed" ) {
 }
 
 SCENARIO( "Scoped connection objects are default constructible" ) {
+	REQUIRE( std::is_default_constructible<nod::scoped_connection>::value == true );
 	GIVEN( "a default scoped constructed connection" ) {
 		nod::scoped_connection scoped;
 		THEN( "the scoped connection will not be considered connected" ) {
@@ -121,7 +122,31 @@ SCENARIO( "Scoped connection objects are default constructible" ) {
 	}
 }
 
+SCENARIO( "Scoped connection objects are move constructible" ) {
+	REQUIRE( std::is_move_constructible<nod::scoped_connection>::value == true );
+	GIVEN( "a signal with a slot managed by a scoped connection" ) {
+		nod::signal<void()> signal;
+		nod::scoped_connection scoped = signal.connect([](){});
+		WHEN( "we try to move construct a scoped connection from the existing scoped connection" ) {
+			nod::scoped_connection connection{ std::move(scoped) };
+			THEN( "the new scoped connection is connected, but we still only have one slot connected" ) {
+				REQUIRE( connection.connected() == true );
+				REQUIRE( signal.slot_count() == 1 );
+			}
+		}
+	}
+}
+
+SCENARIO( "Scoped connection objects are not copy constructible" ) {
+	REQUIRE( std::is_copy_constructible<nod::scoped_connection>::value == false );
+}
+
+SCENARIO( "Scoped connection objects are not copy assignable" ) {
+	REQUIRE( std::is_copy_assignable<nod::scoped_connection>::value == false );
+}
+
 SCENARIO( "Scoped connection objects are move assignable" ) {
+	REQUIRE( std::is_move_assignable<nod::scoped_connection>::value == true );
 	GIVEN( "a signal with a connected slot, managed by a scoped connection" ) {
 		nod::signal<void()> signal;
 		std::ostringstream ss;

--- a/tests/tests/connection_tests.cpp
+++ b/tests/tests/connection_tests.cpp
@@ -121,7 +121,7 @@ SCENARIO( "Scoped connection objects are default constructible" ) {
 	}
 }
 
-SCENARIO( "Scoped connection objects are move constructible" ) {
+SCENARIO( "Scoped connection objects are move assignable" ) {
 	GIVEN( "a signal with a connected slot, managed by a scoped connection" ) {
 		nod::signal<void()> signal;
 		std::ostringstream ss;


### PR DESCRIPTION
Added some tests, and made a minor style fix to the move assignment of `scoped_connection`