### PR TITLE
Fix rvalue reference in signal_accumulator where a universal reference was intended

### DIFF
--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -290,8 +290,8 @@ namespace nod {
 			///
 			/// @param args   Arguments to propagate to the slots of the
 			///               underlying when triggering the signal.
-			result_type operator()( A&&... args ) const {
-				return _signal.trigger_with_accumulator( _init, _func, std::forward<A>(args)... );
+			result_type operator()( A const& ... args ) const {
+				return _signal.trigger_with_accumulator( _init, _func, args... );
 			}
 
 		private:


### PR DESCRIPTION
signal_accumulator::operator() was mistakenly taking an rvalue reference instead of the universal reference that seems to have been intended. This has been changed to a const reference to match the signature of signal_type::operator()