### PR TITLE
Migrated to travis-ci.com and updated badges

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: required
 dist: trusty
 language: cpp
 
+branches:
+  only:
+    - master
+
 matrix:
   include:
     - compiler: gcc

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nod
-[![Build Status](https://travis-ci.org/fr00b0/nod.svg?branch=master)](https://travis-ci.org/fr00b0/nod)
-[![GitHub tag](https://img.shields.io/github/tag/fr00b0/nod.svg?label=version)](https://github.com/fr00b0/nod/releases)
+[![Build Status](https://api.travis-ci.com/fr00b0/nod.svg?branch=master&status=started)](https://travis-ci.com/fr00b0/nod)
+[![GitHub tag](https://img.shields.io/github/v/tag/fr00b0/nod?label=version&sort=semver)](https://github.com/fr00b0/nod/releases)
 
 Dependency free, header only signals and slot library implemented with C++11.
 


### PR DESCRIPTION
 - travis-ci.org is ceasing building, so migrated to travis-ci.com
 - Limit travis builds on branches to only the master branch (travis is configured to also build pull requests)
 - changed the url to the travis status badge
 - changed the url to the tag version badge