### PR TITLE
std::result_of is removed in C++20 in favor of std::invoke_result

### DIFF
--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -269,7 +269,11 @@ namespace nod {
 	{
 		public:
 			/// Result type when calling the accumulating function operator.
+			#if (__cplusplus > 201703L)
+			using result_type = typename std::invoke_result<F, T, typename S::slot_type::result_type>::type;
+			#else
 			using result_type = typename std::result_of<F(T, typename S::slot_type::result_type)>::type;
+			#endif
 
 			/// Construct a signal_accumulator as a proxy to a given signal
 			//


### PR DESCRIPTION
When building with C++20, `result_of` does not exist.

So we check the value of `__cplusplus` to select `invoke_result` instead