### PR TITLE
Add signals and slots definitions similar to Qt5 for class visibility

### DIFF
--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -11,6 +11,8 @@
 #include <type_traits>  // std::is_same
 #include <iterator>     // std::back_inserter
 
+#include "noddefs.h"
+
 namespace nod {
 	// implementational details
 	namespace detail {

--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -11,7 +11,7 @@
 #include <type_traits>  // std::is_same
 #include <iterator>     // std::back_inserter
 
-#include "noddefs.h"
+#include "noddefs.hpp"
 
 namespace nod {
 	// implementational details

--- a/include/nod/noddefs.hpp
+++ b/include/nod/noddefs.hpp
@@ -1,0 +1,12 @@
+#ifndef IG_NOD_INCLUDE_NODDEFS_HPP
+#define IG_NOD_INCLUDE_NODDEFS_HPP
+
+#ifndef signals 
+    #define signals public
+#endif // signals 
+
+#ifndef slots
+    #define slots
+#endif // slots
+
+#endif // IG_NOD_INCLUDE_NODDEFS_HPP


### PR DESCRIPTION
Similar to Qt's `qobjectdefs.h` , I thought it would be nice for classes to use similar `signals:` and `slots:` vernacular.