### PR TITLE
fix `invoke_result` check

### DIFF
--- a/include/nod/nod.hpp
+++ b/include/nod/nod.hpp
@@ -269,7 +269,7 @@ namespace nod {
 	{
 		public:
 			/// Result type when calling the accumulating function operator.
-			#if (__cplusplus > 201703L)
+			#if __cplusplus >= 201703L
 			using result_type = typename std::invoke_result<F, T, typename S::slot_type::result_type>::type;
 			#else
 			using result_type = typename std::result_of<F(T, typename S::slot_type::result_type)>::type;


### PR DESCRIPTION
appleclang's compile seems to identify as c++20 while the standard library identifies as c++17.

`invoke_result` should be available in c++17 already, though